### PR TITLE
ENH: Build pyepics ourself to avoid pitfalls

### DIFF
--- a/pyepics/meta.yaml
+++ b/pyepics/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "3.2.7" %}
+package:
+    name: pyepics
+    version: {{ version }}
+
+source:
+    url: https://github.com/pyepics/pyepics/archive/{{ version }}.tar.gz
+    fn: pyepics-{{ version }}.tar.gz
+
+build:
+    number: 1
+    script: |
+      export PYEPICS_LIBCA=$PREFIX/lib/libca.so
+      echo "Using LIBCA from $PYEPICS_LIBCA"
+      python setup.py install --single-version-externally-managed --record=record.txt
+requirements:
+    build:
+        - python
+        - setuptools
+        - numpy
+        - epics-base
+    run:
+        - python
+        - numpy
+        - epics-base
+
+test:
+    imports:
+        - epics
+
+about:
+    home: http://pyepics.github.io/pyepics/
+    license: Epics Open License
+    summary: Python interface to Epics Channel Access
+
+extra:
+  recipe-maintainers:
+    - ericdill
+    - licode
+    - tacaswell


### PR DESCRIPTION
Literally copy nsls-ii's recipe, change the number to what we need, remove the sha. Their recipe forces pyepics to use the installed libca/libcom from the conda environment rather than creating it's own.