### PR TITLE
ENH: Pyqt patch for pmgr

### DIFF
--- a/build.py
+++ b/build.py
@@ -9,7 +9,7 @@ from socket import gethostname
 
 import binstar_client
 
-PACKAGES = ['epics-base', 'pcaspy', 'pyca', 'pydm', 'pyepics']
+PACKAGES = ['epics-base', 'pcaspy', 'pyca', 'pydm', 'pyepics', 'pyqt']
 PYTHON = ['3.5', '3.6']
 NUMPY = ['1.11', '1.12', '1.13', '1.14']
 BUILD_DIR = str(Path(__file__).parent / 'conda-bld')

--- a/pyqt/bld.bat
+++ b/pyqt/bld.bat
@@ -1,0 +1,17 @@
+:: QtNfc is failing, so we are disabling it for now.
+
+%PYTHON% configure.py ^
+        --verbose ^
+        --confirm-license ^
+        --assume-shared ^
+        --qmake="%LIBRARY_BIN%\qmake.exe" ^
+        --bindir="%LIBRARY_BIN%" ^
+        --spec=win32-msvc%VS_YEAR% ^
+        --disable QtNfc
+if errorlevel 1 exit 1
+
+jom
+if errorlevel 1 exit 1
+
+jom install
+if errorlevel 1 exit 1

--- a/pyqt/build.sh
+++ b/pyqt/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e # Abort on error.
+
+export PING_SLEEP=30s
+export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export BUILD_OUTPUT=$WORKDIR/build.out
+
+touch $BUILD_OUTPUT
+
+dump_output() {
+   echo Tailing the last 500 lines of output:
+   tail -500 $BUILD_OUTPUT
+}
+error_handler() {
+  echo ERROR: An error was encountered with the build.
+  dump_output
+  exit 1
+}
+
+# If an error occurs, run our error handler to output a tail of the build.
+trap 'error_handler' ERR
+
+# Set up a repeating loop to send some output to Travis.
+bash -c "while true; do echo \$(date) - building ...; sleep $PING_SLEEP; done" &
+PING_LOOP_PID=$!
+
+## START BUILD
+$PYTHON configure.py \
+        --verbose \
+        --confirm-license \
+        --assume-shared \
+        -q $PREFIX/bin/qmake
+
+make -j$CPU_COUNT >> $BUILD_OUTPUT 2>&1
+make check >> $BUILD_OUTPUT 2>&1
+make install >> $BUILD_OUTPUT 2>&1
+
+## END BUILD
+
+# The build finished without returning an error so dump a tail of the output.
+dump_output
+
+# Nicely terminate the ping output loop.
+kill $PING_LOOP_PID

--- a/pyqt/configure.patch
+++ b/pyqt/configure.patch
@@ -1,0 +1,18 @@
+--- configure.py
++++ configure.py
+@@ -1871,6 +1871,15 @@
+     if macros is None:
+         return None
+ 
++    # QMake macros may contain comments on the same line so we need to remove them
++    if sys.version[0] == '3':
++        mitems = list(macros.items())
++    else:
++        mitems = macros.iteritems()
++    for macro, value in mitems:
++        if "#" in value:
++            macros[macro] = value.split("#", 1)[0]
++
+     # Qt5 doesn't seem to support the specific macros so add them if they are
+     # missing.
+     if macros.get("INCDIR_QT", "") == "":

--- a/pyqt/meta.yaml
+++ b/pyqt/meta.yaml
@@ -14,6 +14,8 @@ source:
 
 build:
   number: 4
+  patches:
+    - post_init.patch
 
 requirements:
   build:

--- a/pyqt/meta.yaml
+++ b/pyqt/meta.yaml
@@ -1,0 +1,62 @@
+{% set version = "5.6.0" %}
+
+package:
+  name: pyqt
+  version: {{ version }}
+
+source:
+  fn:   PyQt5_gpl-5.6.zip  # [win]
+  url:  http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.6/PyQt5_gpl-5.6.zip  # [win]
+  sha1: 63a03d0f6e7f6e2e9dc90311020fbb2a2edc8cf0  # [win]
+  fn:   PyQt5_gpl-5.6.tar.gz  # [not win]
+  url:  http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.6/PyQt5_gpl-5.6.tar.gz  # [not win]
+  sha1: 8920e4094470ff93f79e257c37c46f5cd0bff7ab  # [not win]
+
+build:
+  number: 4
+
+requirements:
+  build:
+    - python
+    - qt 5.6.*
+    - sip 4.18
+    - jom  # [win]
+  run:
+    - python
+    - qt 5.6.*
+    - sip 4.18
+
+test:
+  files:
+    - pyqt_test.py
+  imports:
+    - PyQt5.QtCore
+    - PyQt5.QtWebKitWidgets  # [linux or win]
+    - PyQt5.QtWebEngineWidgets  # [osx]
+  commands:
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'python pyqt_test.py'  # [linux]
+    - conda inspect linkages -p $PREFIX pyqt  # [not win]
+    - conda inspect objects -p $PREFIX pyqt  # [osx]
+
+about:
+  home: http://www.riverbankcomputing.co.uk/software/pyqt
+  license: Commercial, GPL-2.0, GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'Python binding of the cross-platform GUI toolkit Qt.'
+  description: |
+    "PyQt is a set of Python v2 and v3 bindings for The Qt Company's Qt
+    application framework and runs on all platforms supported by Qt including
+    Windows, MacOS/X and Linux. PyQt5 supports Qt v5. PyQt4 supports Qt v4 and
+    will build against Qt v5. The bindings are implemented as a set of Python
+    modules and contain over 1,000 classes."
+  doc_url: https://www.riverbankcomputing.com/software/pyqt/
+  dev_url: https://github.com/pyqt
+
+extra:
+  recipe-maintainers:
+    - ccordoba12
+    - mingwandroid
+    - gillins
+    - msarahan
+    - ocefpaf

--- a/pyqt/meta.yaml
+++ b/pyqt/meta.yaml
@@ -34,7 +34,7 @@ test:
     - PyQt5.QtWebKitWidgets  # [linux or win]
     - PyQt5.QtWebEngineWidgets  # [osx]
   commands:
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'python pyqt_test.py'  # [linux]
+    - python pyqt_test.py  # [linux]
     - conda inspect linkages -p $PREFIX pyqt  # [not win]
     - conda inspect objects -p $PREFIX pyqt  # [osx]
 

--- a/pyqt/meta.yaml
+++ b/pyqt/meta.yaml
@@ -11,11 +11,11 @@ source:
   fn:   PyQt5_gpl-5.6.tar.gz  # [not win]
   url:  http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.6/PyQt5_gpl-5.6.tar.gz  # [not win]
   sha1: 8920e4094470ff93f79e257c37c46f5cd0bff7ab  # [not win]
+  patches:
+    - post_init.patch
 
 build:
   number: 901
-  patches:
-    - post_init.patch
 
 requirements:
   build:

--- a/pyqt/meta.yaml
+++ b/pyqt/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha1: 8920e4094470ff93f79e257c37c46f5cd0bff7ab  # [not win]
 
 build:
-  number: 4
+  number: 901
   patches:
     - post_init.patch
 

--- a/pyqt/post_init.patch
+++ b/pyqt/post_init.patch
@@ -1,0 +1,30 @@
+*** qpy/QtCore/qpycore_post_init.cpp.in	2017-11-16 11:29:57.188441545 -0800
+--- qpy/QtCore/qpycore_post_init.cpp.in	2017-11-16 11:28:43.940866654 -0800
+***************
+*** 21,26 ****
+--- 21,29 ----
+  #include <Python.h>
+  
+  #include <QMutex>
++ #include <QVector>
++ #include <QList>
++ #include <QAbstractItemModel>
+  
+  #include "qpycore_api.h"
+  #include "qpycore_objectified_strings.h"
+***************
+*** 83,88 ****
+--- 86,98 ----
+      PyQt_PyObject::metatype = qRegisterMetaType<PyQt_PyObject>("PyQt_PyObject");
+      qRegisterMetaTypeStreamOperators<PyQt_PyObject>("PyQt_PyObject");
+  
++     // MCB - Emitting dataChanged, layoutChanged, or layoutAboutToBeChanged
++     // for a QAbstractItemModel will fail, unless this is done.
++     // We can't do it in python, and Qt doesn't want to do it, so here it goes.
++     qRegisterMetaType<QVector<int> >("QVector<int>");
++     qRegisterMetaType<QList<QPersistentModelIndex> >("QList<QPersistentModelIndex>");
++     qRegisterMetaType<QAbstractItemModel::LayoutChangeHint>("QAbstractItemModel::LayoutChangeHint");
++ 
+      // Register the lazy attribute getter.
+      if (sipRegisterAttributeGetter(sipType_QObject, qpycore_get_lazy_attr) < 0)
+          Py_FatalError("PyQt5.QtCore: Failed to register attribute getter");

--- a/pyqt/pyqt_test.py
+++ b/pyqt/pyqt_test.py
@@ -1,0 +1,31 @@
+# From http://zetcode.com/gui/pyqt4/firstprograms/
+
+import sys
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import QTimer
+
+
+def main():
+
+    app = QtWidgets.QApplication(sys.argv)
+
+    w = QtWidgets.QWidget()
+    w.resize(250, 150)
+    w.move(300, 300)
+    w.setWindowTitle('Simple Test')
+    w.show()
+
+    def quit_app():
+        app.quit()
+
+    close_timer = QTimer()
+    close_timer.setInterval(5000)
+    close_timer.setSingleShot(True)
+    close_timer.timeout.connect(quit_app)
+    close_timer.start()
+
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/pyqt/yum_requirements.txt
+++ b/pyqt/yum_requirements.txt
@@ -1,0 +1,2 @@
+xorg-x11-server-Xvfb
+gtk2-devel


### PR DESCRIPTION
The parameter manager is migrating to `pyqt=5.6` and `python=3.6`, and requires Mike's patch to work. This patch gets around the fact that `qRegisterMetaType` does not have a python binding. I would prefer not to host a patched version of `pyqt`, but I'd rather the parameter manager work in the conda ecosystem. Perhaps a future version of `pyqt` will lift the veil and allow us to call `qRegisterMetaType` from python.

The build number has been incremented to 901, because this is building 901 and I wanted it to be clear that this is not the normal build.

Steps taken:
- Copy recipe from `conda-forge`
- Modify until I can build
- Add Mike's patch
- Make sure `pmgr` and `pydm` can run