### PR TITLE
ENH: Leverage multiple threads to speed up build checking

### DIFF
--- a/build.py
+++ b/build.py
@@ -58,7 +58,7 @@ def check_all(files, channel):
                 args = (files, to_build, index, package, channel, py, np)
                 if new_package:
                     # Do the first by itself or conda build may throw errors
-                    res = pool.apply(func=_check_thread, args=args)
+                    pool.apply(func=_check_thread, args=args)
                     new_package = False
                 else:
                     # Do the rest in parallel

--- a/build.py
+++ b/build.py
@@ -120,19 +120,18 @@ def build_all():
     build_path.mkdir()
 
     to_build = check_all(files, channel)
-    built = set()
+    built = []
 
     num = 0
     for _, (package, channel, py, np, full_path) in sorted(to_build.items()):
         if full_path not in built:
             num += 1
-            built.add(full_path)
-            if args.no_build:
-                print(full_path)
-            else:
+            built.append(full_path)
+            if not args.no_build:
                 build(package, channel, py=py, np=np)
                 upload(client, channel, full_path)
 
+    print('')
     if num == 0:
         print('Done. Built 0 packages.')
     else:

--- a/build.py
+++ b/build.py
@@ -64,7 +64,7 @@ def check_all(files, channel):
                     # Do the rest in parallel
                     res = pool.apply_async(func=_check_thread, args=args)
                     results.append(res)
-                    index += 1
+                index += 1
 
     for res in results:
         res.wait()

--- a/build.py
+++ b/build.py
@@ -122,14 +122,18 @@ def build_all():
     to_build = check_all(files, channel)
     built = set()
 
+    num = 0
     for _, (package, channel, py, np, full_path) in sorted(to_build.items()):
         if full_path not in built:
+            num += 1
             built.add(full_path)
             if args.no_build:
                 print(full_path)
             else:
                 build(package, channel, py=py, np=np)
                 upload(client, channel, full_path)
+
+    print('Done. Built {} packages'.format(num))
 
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -133,7 +133,12 @@ def build_all():
                 build(package, channel, py=py, np=np)
                 upload(client, channel, full_path)
 
-    print('Done. Built {} packages'.format(num))
+    if num == 0:
+        print('Done. Built 0 packages.')
+    else:
+        print('Done. Built {} packages:'.format(num))
+        for pkg in built:
+            print(pkg)
 
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -13,8 +13,8 @@ import binstar_client
 
 PACKAGES = ['epics-base', 'pcaspy', 'pyca', 'pydm', 'pyepics', 'pyqt',
             'mysqlclient']
-PYTHON = ['3.5', '3.6']
-NUMPY = ['1.11', '1.12', '1.13', '1.14']
+PYTHON = ['3.6', '3.5']
+NUMPY = ['1.14', '1.13', '1.12', '1.11']
 BUILD_DIR = str(Path(__file__).parent / 'conda-bld')
 
 


### PR DESCRIPTION
- Use `ThreadPool` to launch the subprocesses
- Remove gratuitious prints from the threads
- Add arg for skipping the build/upload

It might be fast enough now to do it in travis, previously it would almost certainly time out in many instances. It still takes a while to do the actual builds, but now we're not wasting time checking if we need to build.

I didn't intend to work on this today. I was intending to add a recipe but then got upset about the build time, then started working on this, and then decided against adding the recipe...

It may be possible to do the build steps in parallel too, but that would require some logging setup and potentially some more battles with conda race conditions.