### PR TITLE
ENH: Update various versions, remove psbuild-rhel6 req

### DIFF
--- a/build.py
+++ b/build.py
@@ -95,10 +95,6 @@ def upload(client, channel, filename):
 
 
 def build_all():
-    allowed_host = 'psbuild-rhel6'
-    if gethostname() != allowed_host:
-        print('You should be running this on {}!'.format(allowed_host))
-        return
     print('Running build script')
     parser = argparse.ArgumentParser()
     parser.add_argument('--channel', action='store', required=True)

--- a/caproto/meta.yaml
+++ b/caproto/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.3.2" %}
 
 package:
     name: caproto

--- a/pydm/meta.yaml
+++ b/pydm/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.2" %}
+{% set version = "1.6.5" %}
 package:
   name: pydm 
   version: {{ version }}

--- a/pyepics/meta.yaml
+++ b/pyepics/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.0" %}
+{% set version = "3.3.3" %}
 package:
     name: pyepics
     version: {{ version }}

--- a/timechart/meta.yaml
+++ b/timechart/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.0" %}
+{% set version = "1.2.2" %}
 
 package:
   name: timechart


### PR DESCRIPTION
Bump numbers of misc packages
psbuild-rhel6 doesn't exist right now

already uploaded to anaconda, built on my local rhel6 machine