### PR TITLE
FIX: Remove stderr accumulation here

### DIFF
--- a/build.py
+++ b/build.py
@@ -102,7 +102,6 @@ def run_and_log(args):
     txt = ''
     process = subprocess.Popen(args,
                                stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT,
                                universal_newlines=True)
     with process.stdout as pipe:
         for line in iter(pipe.readline, ''):


### PR DESCRIPTION
This was getting into some of my output strings and breaking uploads. Every filename was being prepended with the conda compat warning, which is a file that doesn't exist.