### PR TITLE
ENH: Add minimal slice of psdaq for hutch python control

### DIFF
--- a/psdaq-control-minimal/generate_patch.sh
+++ b/psdaq-control-minimal/generate_patch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+VERSION=3.3.14
+git clone --depth 1 --branch $VERSION git@github.com:slac-lcls/lcls2.git patch-tmp
+sed "s/VERSION/'$VERSION'/" setup.py > patch-tmp/psdaq/setup.py
+pushd patch-tmp
+git diff > ../setup.patch
+popd
+rm -rf patch-tmp

--- a/psdaq-control-minimal/meta.yaml
+++ b/psdaq-control-minimal/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: psdaq-control-minimal
+  version: 3.3.14
+
+source:
+  git_url: https://github.com/slac-lcls/lcls2.git
+  git_rev: 3.3.14
+  patches:
+    - setup.patch
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install ./psdaq -vv
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - p4p
+    - psalg
+    - psana
+    - transitions

--- a/psdaq-control-minimal/meta.yaml
+++ b/psdaq-control-minimal/meta.yaml
@@ -19,7 +19,18 @@ requirements:
     - pip
   run:
     - python
+    - bluesky
+    - numpy
+    - ophyd
     - p4p
+    - pprint
     - psalg
     - psana
+    - pyepics
     - transitions
+    - zeromq
+
+test:
+  imports:
+    - psdaq.control
+    - psdaq.control.bluesky_simple

--- a/psdaq-control-minimal/meta.yaml
+++ b/psdaq-control-minimal/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - numpy
     - ophyd
     - p4p
-    - pprint
     - psalg
     - psana
     - pyepics

--- a/psdaq-control-minimal/setup.patch
+++ b/psdaq-control-minimal/setup.patch
@@ -1,5 +1,5 @@
 diff --git a/psdaq/setup.py b/psdaq/setup.py
-index 28bd16a..d988e3b 100644
+index 28bd16a..bb3a6f6 100644
 --- a/psdaq/setup.py
 +++ b/psdaq/setup.py
 @@ -1,56 +1,9 @@
@@ -62,5 +62,5 @@ index 28bd16a..d988e3b 100644
 -       },
 +       description = 'LCLS II DAQ control bits needed for hutch python',
 +       version = '3.3.14',
-+       packages = 'psdaq.control'
++       packages = ['psdaq.control']
  )

--- a/psdaq-control-minimal/setup.patch
+++ b/psdaq-control-minimal/setup.patch
@@ -1,33 +1,17 @@
-From 301c785a6006789aedf84b4cefead82249d0499e Mon Sep 17 00:00:00 2001
-From: Zachary Lentz <zlentz@slac.stanford.edu>
-Date: Mon, 29 Mar 2021 13:53:54 -0700
-Subject: [PATCH] MNT: setup patch for minimal control build
-
----
- psdaq/setup.py | 58 ++++----------------------------------------------
- 1 file changed, 4 insertions(+), 54 deletions(-)
-
 diff --git a/psdaq/setup.py b/psdaq/setup.py
-index 8590945..8a70ac5 100644
+index 28bd16a..d988e3b 100644
 --- a/psdaq/setup.py
 +++ b/psdaq/setup.py
-@@ -1,62 +1,12 @@
- import os
- from setuptools import setup, find_packages
- 
--VERSION = '0.0.0'
--version_env = os.environ.get('VERSION')
--if version_env:
--    VERSION = version_env
-+VERSION = '3.3.14'
+@@ -1,56 +1,9 @@
+-from setuptools import setup, find_packages
++from setuptools import setup
  
  setup(
 -       name = 'psdaq',
 +       name = 'psdaq-control-minimal',
         license = 'LCLS II',
 -       description = 'LCLS II DAQ package',
-+       description = 'LCLS II DAQ control minimal',
-        version = VERSION,
+-
 -       packages = find_packages(),
 -       package_data={'psdaq.control_gui': ['data/icons/*.png','data/icons/*.gif'],},
 -
@@ -76,8 +60,7 @@ index 8590945..8a70ac5 100644
 -                'seqprogram = psdaq.seq.seqprogram:main',
 -              ]
 -       },
++       description = 'LCLS II DAQ control bits needed for hutch python',
++       version = '3.3.14',
 +       packages = 'psdaq.control'
  )
--- 
-2.30.2
-

--- a/psdaq-control-minimal/setup.patch
+++ b/psdaq-control-minimal/setup.patch
@@ -1,0 +1,83 @@
+From 301c785a6006789aedf84b4cefead82249d0499e Mon Sep 17 00:00:00 2001
+From: Zachary Lentz <zlentz@slac.stanford.edu>
+Date: Mon, 29 Mar 2021 13:53:54 -0700
+Subject: [PATCH] MNT: setup patch for minimal control build
+
+---
+ psdaq/setup.py | 58 ++++----------------------------------------------
+ 1 file changed, 4 insertions(+), 54 deletions(-)
+
+diff --git a/psdaq/setup.py b/psdaq/setup.py
+index 8590945..8a70ac5 100644
+--- a/psdaq/setup.py
++++ b/psdaq/setup.py
+@@ -1,62 +1,12 @@
+ import os
+ from setuptools import setup, find_packages
+ 
+-VERSION = '0.0.0'
+-version_env = os.environ.get('VERSION')
+-if version_env:
+-    VERSION = version_env
++VERSION = '3.3.14'
+ 
+ setup(
+-       name = 'psdaq',
++       name = 'psdaq-control-minimal',
+        license = 'LCLS II',
+-       description = 'LCLS II DAQ package',
++       description = 'LCLS II DAQ control minimal',
+        version = VERSION,
+-       packages = find_packages(),
+-       package_data={'psdaq.control_gui': ['data/icons/*.png','data/icons/*.gif'],},
+-
+-       scripts = ['psdaq/procmgr/procmgr','psdaq/procmgr/procstat','psdaq/procmgr/condaProcServ'],
+-
+-       entry_points={
+-            'console_scripts': [
+-                'control = psdaq.control.control:main',
+-                'selectPlatform = psdaq.control.selectPlatform:main',
+-                'showPlatform = psdaq.control.showPlatform:main',
+-                'daqstate = psdaq.control.daqstate:main',
+-                'currentexp = psdaq.control.currentexp:main',
+-                'testClient2 = psdaq.control.testClient2:main',
+-                'testAsyncErr = psdaq.control.testAsyncErr:main',
+-                'testFileReport = psdaq.control.testFileReport:main',
+-                'configdb = psdaq.configdb.configdb:main',
+-                'getrun = psdaq.control.getrun:main',
+-                'groupca = psdaq.cas.groupca:main',
+-                'partca = psdaq.cas.partca:main',
+-                'xpmpva = psdaq.cas.xpmpva:main',
+-                'deadca = psdaq.cas.deadca:main',
+-                'dtica = psdaq.cas.dtica:main',
+-                'dticas = psdaq.cas.dticas:main',
+-                'hsdca = psdaq.cas.hsdca:main',
+-                'hsdcas = psdaq.cas.hsdcas:main',
+-                'hsdpva = psdaq.cas.hsdpva:main',
+-                'hsdpvs = psdaq.cas.hsdpvs:main',
+-                'pvatable = psdaq.cas.pvatable:main',
+-                'pvant = psdaq.cas.pvant:main',
+-                'campvs = psdaq.cas.campvs:main',
+-                'tprca = psdaq.cas.tprca:main',
+-                'tprcas = psdaq.cas.tprcas:main',
+-                'xpmioc = psdaq.cas.xpmioc:main',
+-                'bldcas = psdaq.cas.bldcas:main',
+-                'hpsdbuscas = psdaq.cas.hpsdbuscas:main',
+-                'wave8pvs = psdaq.cas.wave8pvs:main',
+-                'pyxpm = psdaq.pyxpm.pyxpm:main',
+-                'amccpromload = psdaq.pyxpm.amccpromload:main',
+-                'pykcu = psdaq.pykcu.pykcu:main',
+-                'control_gui = psdaq.control_gui.app.control_gui:control_gui',
+-                'bluesky_simple = psdaq.control.bluesky_simple:main',
+-                'opal_config_scan = psdaq.control.opal_config_scan:main',
+-                'ts_config_scan = psdaq.control.ts_config_scan:main',
+-                'epics_exporter = psdaq.cas.epics_exporter:main',
+-                'seqplot = psdaq.seq.seqplot:main',
+-                'seqprogram = psdaq.seq.seqprogram:main',
+-              ]
+-       },
++       packages = 'psdaq.control'
+ )
+-- 
+2.30.2
+

--- a/psdaq-control-minimal/setup.py
+++ b/psdaq-control-minimal/setup.py
@@ -1,0 +1,12 @@
+import os
+from setuptools import setup, find_packages
+
+VERSION = '3.3.14'
+
+setup(
+       name = 'psdaq-control-minimal',
+       license = 'LCLS II',
+       description = 'LCLS II DAQ control bits needed for hutch python',
+       version = VERSION,
+       packages = 'psdaq.control'
+)

--- a/psdaq-control-minimal/setup.py
+++ b/psdaq-control-minimal/setup.py
@@ -1,7 +1,4 @@
-import os
-from setuptools import setup, find_packages
-
-VERSION = '3.3.14'
+from setuptools import setup
 
 setup(
        name = 'psdaq-control-minimal',

--- a/psdaq-control-minimal/setup.py
+++ b/psdaq-control-minimal/setup.py
@@ -5,5 +5,5 @@ setup(
        license = 'LCLS II',
        description = 'LCLS II DAQ control bits needed for hutch python',
        version = VERSION,
-       packages = 'psdaq.control'
+       packages = ['psdaq.control']
 )


### PR DESCRIPTION
As a hold-over until the DAQ team is done with a minimized zmq-only DAQ interface, which may become an independent package or land as part of `pcdsdaq`.

This is `psdaq`, except with a patch to the `setup.py` file and a minimized set of dependencies.